### PR TITLE
1.3.2 Development (MC-1.11.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ target/classes/iocia/network/plugins/iconfig/IConfigMain.class
 target/classes/iocia/network/plugins/iconfig/LinkedConfigs.class
 target/classes/iocia/network/plugins/iconfig/PlayerConfigs.class
 target/classes/plugin.yml
+out/artifacts/IConfig_jar/IConfig.jar

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ IConfig.iml
 
 .idea/uiDesigner.xml
 .idea/artifacts/IConfig_jar.xml
+target/classes/iocia/network/plugins/iconfig/components/ConfigHandler.class
+target/classes/iocia/network/plugins/iconfig/components/FileLoader.class
+target/classes/iocia/network/plugins/iconfig/IConfig.class
+target/classes/iocia/network/plugins/iconfig/IConfigMain.class
+target/classes/iocia/network/plugins/iconfig/LinkedConfigs.class
+target/classes/iocia/network/plugins/iconfig/PlayerConfigs.class
+target/classes/plugin.yml

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ IConfig.iml
 .idea/kotlinc.xml
 
 .idea/uiDesigner.xml
+.idea/artifacts/IConfig_jar.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>iocia.network.plugins.iconfig</groupId>
     <artifactId>IConfig</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>iocia.network.plugins.iconfig</groupId>
     <artifactId>IConfig</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/iocia/network/plugins/iconfig/components/ConfigHandler.java
+++ b/src/iocia/network/plugins/iconfig/components/ConfigHandler.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 /**
  * Manages the configuration data which is saved to and accessed from the system file.
@@ -56,12 +57,12 @@ public abstract class ConfigHandler extends FileLoader {
      * This means initial configuration files can be created with commented lines
      * anywhere and the exact order of the configuration options can be controlled.
      * @param internalFile InputStream of the internal jar file to copy.
-     * @param options Used to specify extra options when copying the file.
      * @throws IOException If an I/O error occurs while reading or writing.
-     * @see CopyOption for information regarding the extra options.
      */
-    public void copyPremadeConfig(InputStream internalFile, CopyOption... options) throws IOException, InvalidConfigurationException {
-        Files.copy(internalFile, Paths.get(systemFile.getAbsolutePath()), options);
+    public void copyPremadeConfig(InputStream internalFile) throws IOException, InvalidConfigurationException {
+        if (!isFirstLoad())
+            return;
+        Files.copy(internalFile, Paths.get(systemFile.getAbsolutePath()), StandardCopyOption.REPLACE_EXISTING);
         load(systemFile);
     }
 

--- a/src/iocia/network/plugins/iconfig/components/ConfigHandler.java
+++ b/src/iocia/network/plugins/iconfig/components/ConfigHandler.java
@@ -16,120 +16,26 @@ import java.nio.file.Paths;
 public abstract class ConfigHandler extends FileLoader {
 
     /*---Constructors---*/
-    /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
-     *
-     * @param baseDirectory  Base-directory which acts as the master parent directory. Usually is the
-     *                       directory given to each plugin by the Spigot server, but can be
-     *                       altered to unify plugins under a single directory.
-     * @param subDirectories Any sub-directories within the base-directory. Useful for organizing
-     *                       many configuration files.
-     * @param fileName       File name of the configuration file. WILL automatically add a '.yml' extension
-     *                       to the file. Any file extensions put in the file name will have no effect on the
-     *                       file type of the created files; this is to ensure all configuration files are created
-     *                       as YAML files.
-     * @throws IOException                   Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
-     */
     public ConfigHandler(File baseDirectory, String subDirectories, String fileName) throws IOException, InvalidConfigurationException {
         super(baseDirectory, subDirectories, fileName);
     }
 
-    /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
-     *
-     * @param baseDirectory  Base-directory which acts as the master parent directory. Usually is the
-     *                       directory given to each plugin by the Spigot server, but can be
-     *                       altered to unify plugins under a single directory.
-     * @param subDirectories Any sub-directories within the base-directory. Useful for organizing
-     *                       many configuration files.
-     * @param fileName       File name of the configuration file. WILL automatically add a '.yml' extension
-     *                       to the file. Any file extensions put in the file name will have no effect on the
-     *                       file type of the created files; this is to ensure all configuration files are created
-     *                       as YAML files.
-     * @throws IOException                   Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
-     */
     public ConfigHandler(String baseDirectory, String subDirectories, String fileName) throws IOException, InvalidConfigurationException {
         super(baseDirectory, subDirectories, fileName);
     }
 
-    /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
-     *
-     * @param plugin         Instance of main class which extends JavaPlugin. Will ensure the
-     *                       file is located within the folder created for the plugin.
-     * @param subDirectories Any sub-directories within the base-directory. Useful for organizing
-     *                       many configuration files.
-     * @param fileName       File name of the configuration file. WILL automatically add a '.yml' extension
-     *                       to the file. Any file extensions put in the file name will have no effect on the
-     *                       file type of the created files; this is to ensure all configuration files are created
-     *                       as YAML files.
-     * @throws IOException                   Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
-     */
     public ConfigHandler(JavaPlugin plugin, String subDirectories, String fileName) throws IOException, InvalidConfigurationException {
         super(plugin, subDirectories, fileName);
     }
 
-    /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
-     *
-     * @param baseDirectory Base-directory which acts as the master parent directory. Usually is the
-     *                      directory given to each plugin by the Spigot server, but can be
-     *                      altered to unify plugins under a single directory.
-     * @param fileName      File name of the configuration file. WILL automatically add a '.yml' extension
-     *                      to the file. Any file extensions put in the file name will have no effect on the
-     *                      file type of the created files; this is to ensure all configuration files are created
-     *                      as YAML files.
-     * @throws IOException                   Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
-     */
     public ConfigHandler(File baseDirectory, String fileName) throws IOException, InvalidConfigurationException {
         super(baseDirectory, fileName);
     }
 
-    /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
-     *
-     * @param baseDirectory Base-directory which acts as the master parent directory. Usually is the
-     *                      directory given to each plugin by the Spigot server, but can be
-     *                      altered to unify plugins under a single directory.
-     * @param fileName      File name of the configuration file. WILL automatically add a '.yml' extension
-     *                      to the file. Any file extensions put in the file name will have no effect on the
-     *                      file type of the created files; this is to ensure all configuration files are created
-     *                      as YAML files.
-     * @throws IOException                   Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
-     */
     public ConfigHandler(String baseDirectory, String fileName) throws IOException, InvalidConfigurationException {
         super(baseDirectory, fileName);
     }
 
-    /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
-     *
-     * @param plugin   Instance of main class which extends JavaPlugin. Will ensure the
-     *                 file is located within the folder created for the plugin.
-     * @param fileName File name of the configuration file. WILL automatically add a '.yml' extension
-     *                 to the file. Any file extensions put in the file name will have no effect on the
-     *                 file type of the created files; this is to ensure all configuration files are created
-     *                 as YAML files.
-     * @throws IOException                   Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
-     */
     public ConfigHandler(JavaPlugin plugin, String fileName) throws IOException, InvalidConfigurationException {
         super(plugin, fileName);
     }

--- a/src/iocia/network/plugins/iconfig/components/FileLoader.java
+++ b/src/iocia/network/plugins/iconfig/components/FileLoader.java
@@ -44,7 +44,7 @@ public abstract class FileLoader extends YamlConfiguration {
         if (subDirectories == null) {
             systemFile = new File(baseDirectory, fileExtender.toString());
         } else {
-            systemFile = new File(baseDirectory + File.separator + fileExtender.toString());
+            systemFile = new File(baseDirectory + File.separator + subDirectories, fileExtender.toString());
         }
         systemFile.getParentFile().mkdirs();
         isFirstLoad = systemFile.createNewFile();

--- a/src/iocia/network/plugins/iconfig/components/FileLoader.java
+++ b/src/iocia/network/plugins/iconfig/components/FileLoader.java
@@ -19,9 +19,13 @@ public abstract class FileLoader extends YamlConfiguration {
 
     /*---Constructors---*/
     /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
+     * Attempts to create a {@link File} object for the newly created configuration.
+     * If the physical system file does not exist, one will be created. Will NOT delete
+     * an already existing system file. Any required directories will also be created.
+     *
+     * Using this constructor allows the possibility of creating configuration files
+     * which are located outside of the plugin's default directory.
+     *
      * @param baseDirectory Base-directory which acts as the master parent directory. Usually is the
      *                      directory given to each plugin by the Spigot server, but can be
      *                      altered to unify plugins under a single directory.
@@ -32,7 +36,7 @@ public abstract class FileLoader extends YamlConfiguration {
      *                 file type of the created files; this is to ensure all configuration files are created
      *                 as YAML files.
      * @throws IOException Thrown when either a directory or the file cannot be created.
-     * @throws InvalidConfigurationException Thrown if file has an invalid configuration.
+     * @throws InvalidConfigurationException Thrown if the file has an invalid configuration.
      */
     public FileLoader(File baseDirectory, String subDirectories, String fileName) throws IOException, InvalidConfigurationException {
         StringBuilder fileExtender = new StringBuilder(fileName);
@@ -48,9 +52,13 @@ public abstract class FileLoader extends YamlConfiguration {
     }
 
     /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
+     * Attempts to create a {@link File} object for the newly created configuration.
+     * If the physical system file does not exist, one will be created. Will NOT delete
+     * an already existing system file. Any required directories will also be created.
+     *
+     * Using this constructor allows the possibility of creating configuration files
+     * which are located outside of the plugin's default directory.
+     *
      * @param baseDirectory Base-directory which acts as the master parent directory. Usually is the
      *                      directory given to each plugin by the Spigot server, but can be
      *                      altered to unify plugins under a single directory.
@@ -68,11 +76,12 @@ public abstract class FileLoader extends YamlConfiguration {
     }
 
     /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
+     * Attempts to create a {@link File} object for the newly created configuration.
+     * If the physical system file does not exist, one will be created. Will NOT delete
+     * an already existing system file. Any required directories will also be created.
+     *
      * @param plugin Instance of main class which extends JavaPlugin. Will ensure the
-     *               file is located within the folder created for the plugin.
+     *               file is located within the directory created for the plugin.
      * @param subDirectories Any sub-directories within the base-directory. Useful for organizing
      *                       many configuration files.
      * @param fileName File name of the configuration file. WILL automatically add a '.yml' extension
@@ -87,9 +96,13 @@ public abstract class FileLoader extends YamlConfiguration {
     }
 
     /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
+     * Attempts to create a {@link File} object for the newly created configuration.
+     * If the physical system file does not exist, one will be created. Will NOT delete
+     * an already existing system file. Any required directories will also be created.
+     *
+     * Using this constructor allows the possibility of creating configuration files
+     * which are located outside of the plugin's default directory.
+     *
      * @param baseDirectory Base-directory which acts as the master parent directory. Usually is the
      *                      directory given to each plugin by the Spigot server, but can be
      *                      altered to unify plugins under a single directory.
@@ -105,9 +118,13 @@ public abstract class FileLoader extends YamlConfiguration {
     }
 
     /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
+     * Attempts to create a {@link File} object for the newly created configuration.
+     * If the physical system file does not exist, one will be created. Will NOT delete
+     * an already existing system file. Any required directories will also be created.
+     *
+     * Using this constructor allows the possibility of creating configuration files
+     * which are located outside of the plugin's default directory.
+     *
      * @param baseDirectory Base-directory which acts as the master parent directory. Usually is the
      *                      directory given to each plugin by the Spigot server, but can be
      *                      altered to unify plugins under a single directory.
@@ -123,9 +140,10 @@ public abstract class FileLoader extends YamlConfiguration {
     }
 
     /**
-     * Attempts to create a new configuration file under the given file name.
-     * Will attempt create any required parent folders based on the given base-folder
-     * and sub-folders. Will NOT delete an already existing file or directory.
+     * Attempts to create a {@link File} object for the newly created configuration.
+     * If the physical system file does not exist, one will be created. Will NOT delete
+     * an already existing system file. Any required directories will also be created.
+     *
      * @param plugin Instance of main class which extends JavaPlugin. Will ensure the
      *               file is located within the folder created for the plugin.
      * @param fileName File name of the configuration file. WILL automatically add a '.yml' extension
@@ -144,6 +162,7 @@ public abstract class FileLoader extends YamlConfiguration {
     /**
      * Used to determine if the configuration file had been created
      * for the first time.
+     *
      * @return true if newly created; false if not.
      */
     public boolean isFirstLoad() {

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,4 +1,4 @@
 name: IConfig
 main: iocia.network.plugins.iconfig.IConfigMain
-version: 1.3.0
+version: 1.3.1
 author: Hunky524

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,4 +1,4 @@
 name: IConfig
 main: iocia.network.plugins.iconfig.IConfigMain
-version: 1.3.1
+version: 1.3.2
 author: Hunky524


### PR DESCRIPTION
(#) JavaDoc updates
(#) Fixed FileLoader not creating sub-directories in some cases
(#) Added isFirstLoad check onto copyPremadeConfig so Files#copy can correctly copy data safely.